### PR TITLE
Misc updates

### DIFF
--- a/api/activetigger/server.py
+++ b/api/activetigger/server.py
@@ -116,15 +116,11 @@ class Server:
         self.db = self.path / self.db_name
 
         # create directories
-        if not self.path.exists():
-            os.makedirs(self.path)
-        if not (self.path / "static").exists():
-            os.mkdir((self.path / "static"))
-        if not self.path_models.exists():
-            os.makedirs(self.path_models)
+        (self.path / "static").mkdir(parents=True, exist_ok=True)
+        self.path_models.mkdir(exist_ok=True):
 
         # attributes of the server
-        self.projects: dict = {}
+        self.projects = {}
         self.db_manager = DatabaseManager(self.db)
         self.queue = Queue(self.n_workers)
         self.users = Users(self.db_manager)
@@ -157,7 +153,7 @@ class Server:
         Log action in the database
         """
         self.db_manager.add_log(user, action, project, connect)
-        logger.info(f"{action} from {user} in project {project}")
+        logger.info("%s from %s in project %s", action, user, project)
 
     def get_logs(
         self, project_slug: str, limit: int, partial: bool = True


### PR DESCRIPTION
1. use pathlib to create directory.

Testing existance then create directory is a
prblem as it can introduce race condition. Indeed
the directory could be created by another process
between the test and the creation.

We use parents=True and exist_ok=True to avoid
race condition and create the two directories in
one go.

2. do not need to annotate the type of the server attributes when already defined in the class.

3. use logger.info with format string to log the action, user and project. You  usuall prefer this as  and f-string for many reasons:

   a. it is faster (lazy evaluation of parameters) b. it is necessary if you ever want to use structured logging. (it stors the format message separately from the arguments, and you can ask "show me all the logs with the format message XXX")