### PR TITLE
Create scafolding ruff Ruff config

### DIFF
--- a/api/activetigger/__main__.py
+++ b/api/activetigger/__main__.py
@@ -1,6 +1,7 @@
-import uvicorn
 import argparse
 from pathlib import Path
+
+import uvicorn
 
 if __name__ == "__main__":
     """

--- a/api/activetigger/functions.py
+++ b/api/activetigger/functions.py
@@ -786,7 +786,7 @@ def generate(
     results = []
 
     # loop on all elements
-    for index, row in df.iterrows():
+    for _index, row in df.iterrows():
         # test for interruption
         if event is not None:
             if event.is_set():

--- a/api/activetigger/schemes.py
+++ b/api/activetigger/schemes.py
@@ -49,7 +49,7 @@ class Schemes:
         return f"Coding schemes available {self.available()}"
 
     def get_scheme_data(
-        self, scheme: str, complete: bool = False, kind: list | str = ["train"]
+        self, scheme: str, complete: bool = False, kind: list | str = None
     ) -> DataFrame:
         """
         Get data from a scheme : id, text, context, labels
@@ -58,6 +58,8 @@ class Schemes:
         Comments:
             For the moment tags can be add, test, predict, reconciliation
         """
+        if kind is None:
+            kind = ["train"]
         if scheme not in self.available():
             return {"error": "Scheme doesn't exist"}
 

--- a/api/activetigger/server.py
+++ b/api/activetigger/server.py
@@ -692,7 +692,7 @@ class Project(Server):
         sample: str = "untagged",
         user: str = "user",
         label: None | str = None,
-        history: list = [],
+        history: list = None,
         frame: None | list = None,
         filter: str | None = None,
     ) -> dict:
@@ -709,6 +709,8 @@ class Project(Server):
         filter is a regex to use on the corpus
         """
 
+        if history is None:
+            history = []
         if scheme not in self.schemes.available():
             return {"error": "Scheme doesn't exist"}
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -44,7 +44,7 @@ line-length = 100
 [tool.ruff.lint]
 extend-select = [
 #  "B",           # flake8-bugbear
-#  "I",           # isort
+  "I",           # isort
 #  "ARG",         # flake8-unused-arguments
 #  "C4",          # flake8-comprehensions
 #  "EM",          # flake8-errmsg

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -37,3 +37,45 @@ dependencies = ["fastapi[all]",
 		"plotly",
 		"matplotlib",
 		"scikit-learn"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+extend-select = [
+#  "B",           # flake8-bugbear
+#  "I",           # isort
+#  "ARG",         # flake8-unused-arguments
+#  "C4",          # flake8-comprehensions
+#  "EM",          # flake8-errmsg
+#  "ICN",         # flake8-import-conventions
+#  "G",           # flake8-logging-format
+#  "PGH",         # pygrep-hooks
+#  "PIE",         # flake8-pie
+#  "PL",          # pylint
+#  "PTH",         # flake8-use-pathlib
+#  "PT",          # flake8-pytest-style
+#  "RET",         # flake8-return
+#  "RUF",         # Ruff-specific
+#  "SIM",         # flake8-simplify
+#  "T20",         # flake8-print
+#  "UP",          # pyupgrade
+#  "YTT",         # flake8-2020
+#  "EXE",         # flake8-executable
+#  "PYI",         # flake8-pyi
+#  "S",           # flake8-bandit
+#  "G",        # .format and co in logging methods
+]
+ignore = [
+#  "E501",     # E501 Line too long (158 > 100 characters)
+#  "SIM105",   # SIM105 Use `contextlib.suppress(...)`
+#  "PLR",      # Design related pylint codes
+#  "S101",     # Use of `assert` detected
+]
+unfixable = [
+  # Don't touch print statements
+  "T201",
+  # Don't touch noqa lines
+  "RUF100",
+]
+

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -45,12 +45,13 @@ line-length = 100
 extend-select = [
 #  "B",           # flake8-bugbear
   "I",           # isort
+# that will be a problem for pytest fixture unless you swap with the usefixture decorator https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures
 #  "ARG",         # flake8-unused-arguments
 #  "C4",          # flake8-comprehensions
 #  "EM",          # flake8-errmsg
-#  "ICN",         # flake8-import-conventions
+  "ICN",         # flake8-import-conventions
 #  "G",           # flake8-logging-format
-#  "PGH",         # pygrep-hooks
+  "PGH",         # pygrep-hooks
 #  "PIE",         # flake8-pie
 #  "PL",          # pylint
 #  "PTH",         # flake8-use-pathlib
@@ -60,11 +61,10 @@ extend-select = [
 #  "SIM",         # flake8-simplify
 #  "T20",         # flake8-print
 #  "UP",          # pyupgrade
-#  "YTT",         # flake8-2020
-#  "EXE",         # flake8-executable
+  "YTT",         # flake8-2020
+  "EXE",         # flake8-executable
 #  "PYI",         # flake8-pyi
 #  "S",           # flake8-bandit
-#  "G",        # .format and co in logging methods
 ]
 ignore = [
 #  "E501",     # E501 Line too long (158 > 100 characters)

--- a/api/tests/test_project.py
+++ b/api/tests/test_project.py
@@ -2,6 +2,7 @@ import os
 import shutil
 
 import pytest
+
 from activetigger.datamodels import ProjectDataModel
 from activetigger.server import Server
 

--- a/api/tests/test_server.py
+++ b/api/tests/test_server.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy
+
 from activetigger.datamodels import ProjectDataModel
 from activetigger.server import Queue, Server, Users
 


### PR DESCRIPTION
As a suggestion, 

I have not enabled most rules, I and invite you to try them (some of them might be overzealous). 

Here for example I enable some rule that warn about default mutable argument and why it's bad:

```
In [1]: def f(a=[]):
   ...:     return a
   ...:

In [2]: x = f()

In [3]: x.append('coucou')

In [4]: f()
Out[4]: ['coucou']
```

note that ruff has a `--fix` option for many of those.