### PR TITLE
Start to separate entities from services into different layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ frontend/public/favicon_old.ico
 frontend/src/assets/at_old.png
 api/mlruns
 site/
+**/*.sql

--- a/api/activetigger/api.py
+++ b/api/activetigger/api.py
@@ -157,7 +157,9 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 app.mount("/static", StaticFiles(directory=server.path / "static"), name="static")
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")  # defining the authentification object
+oauth2_scheme = OAuth2PasswordBearer(
+    tokenUrl="token"
+)  # defining the authentification object
 
 
 async def check_processes(timer, step: int = 1) -> None:
@@ -350,8 +352,12 @@ async def login_for_access_token(
         raise HTTPException(status_code=401, detail=user["error"])
 
     # create new token for the user
-    access_token = server.create_access_token(data={"sub": user.username}, expires_min=120)
-    return TokenModel(access_token=access_token, token_type="bearer", status=user.status)
+    access_token = server.create_access_token(
+        data={"sub": user.username}, expires_min=120
+    )
+    return TokenModel(
+        access_token=access_token, token_type="bearer", status=user.status
+    )
 
 
 @app.post("/users/disconnect", dependencies=[Depends(verified_user)])
@@ -408,7 +414,9 @@ async def create_user(
     Create user
     """
     test_rights("create user", current_user.username)
-    r = server.users.add_user(username_to_create, password, status, current_user.username, mail)
+    r = server.users.add_user(
+        username_to_create, password, status, current_user.username, mail
+    )
     if "error" in r:
         raise HTTPException(status_code=500, detail=r["error"])
     return None
@@ -485,7 +493,9 @@ async def get_auth(username: str) -> List:
 
 
 @app.get("/logs", dependencies=[Depends(verified_user)])
-async def get_logs(username: str, project_slug: str = "all", limit: int = 100) -> TableOutModel:
+async def get_logs(
+    username: str, project_slug: str = "all", limit: int = 100
+) -> TableOutModel:
     """
     Get all logs for a username/project
     """
@@ -654,7 +664,9 @@ async def new_project(
         raise HTTPException(status_code=500, detail=r["error"])
 
     # log action
-    server.log_action(current_user.username, "INFO create project", project.project_name)
+    server.log_action(
+        current_user.username, "INFO create project", project.project_name
+    )
 
     return r["success"]
 
@@ -799,9 +811,9 @@ async def get_list_elements(
     if "error" in extract:
         raise HTTPException(status_code=500, detail=extract["error"])
     df = extract["batch"].fillna(" ")
-    table = (df.reset_index()[["id", "timestamp", "labels", "text", "comment"]]).to_dict(
-        orient="records"
-    )
+    table = (
+        df.reset_index()[["id", "timestamp", "labels", "text", "comment"]]
+    ).to_dict(orient="records")
     return TableOutModel(
         items=table,
         total=extract["total"],
@@ -911,7 +923,9 @@ async def postgenerate(
     """
 
     # get subset of unlabelled elements
-    extract = project.schemes.get_table(request.scheme, 0, request.n_batch, request.mode)
+    extract = project.schemes.get_table(
+        request.scheme, 0, request.n_batch, request.mode
+    )
 
     if "error" in extract:
         raise HTTPException(status_code=500, detail=extract["error"])
@@ -969,7 +983,9 @@ async def stop_generation(
     r = server.queue.kill(unique_id)
     if "error" in r:
         raise HTTPException(status_code=500, detail=r["error"])
-    server.log_action(current_user.username, "INFO stop generation", project.params.project_slug)
+    server.log_action(
+        current_user.username, "INFO stop generation", project.params.project_slug
+    )
     return None
 
 
@@ -983,7 +999,9 @@ async def getgenerate(
     Get elements from prediction
     """
     try:
-        table = project.generations.get_generated(project.name, current_user.username, n_elements)
+        table = project.generations.get_generated(
+            project.name, current_user.username, n_elements
+        )
     except Exception:
         raise HTTPException(status_code=500, detail="Error in loading generated data")
 
@@ -1005,7 +1023,9 @@ async def get_element(
     """
     Get specific element
     """
-    r = project.get_element(element_id, scheme=scheme, user=current_user.username, dataset=dataset)
+    r = project.get_element(
+        element_id, scheme=scheme, user=current_user.username, dataset=dataset
+    )
     if "error" in r:
         raise HTTPException(status_code=500, detail=r["error"])
     return ElementOutModel(**r)
@@ -1092,7 +1112,9 @@ async def rename_label(
             raise HTTPException(status_code=500, detail=r["error"])
 
     # convert the tags from the previous label
-    r = project.schemes.convert_annotations(former_label, new_label, scheme, current_user.username)
+    r = project.schemes.convert_annotations(
+        former_label, new_label, scheme, current_user.username
+    )
     if "error" in r:
         raise HTTPException(status_code=500, detail=r["error"])
 
@@ -1204,7 +1226,9 @@ async def post_schemes(
         )
         if "error" in r:
             raise HTTPException(status_code=500, detail=r["error"])
-        server.log_action(current_user.username, f"ADD SCHEME: scheme {scheme.name}", project.name)
+        server.log_action(
+            current_user.username, f"ADD SCHEME: scheme {scheme.name}", project.name
+        )
         return None
     if action == "delete":
         r = project.schemes.delete_scheme(scheme.name)
@@ -1264,7 +1288,9 @@ async def post_embeddings(
         raise HTTPException(status_code=500, detail=r["error"])
 
     # Log and return
-    server.log_action(current_user.username, f"INFO Compute feature {feature.type}", project.name)
+    server.log_action(
+        current_user.username, f"INFO Compute feature {feature.type}", project.name
+    )
     return WaitingModel(detail=f"computing {feature.type}, it could take a few minutes")
 
 
@@ -1281,7 +1307,9 @@ async def delete_feature(
     r = project.features.delete(name)
     if "error" in r:
         raise HTTPException(status_code=400, detail=r["error"])
-    server.log_action(current_user.username, f"INFO delete feature {name}", project.name)
+    server.log_action(
+        current_user.username, f"INFO delete feature {name}", project.name
+    )
     return None
 
 
@@ -1336,7 +1364,9 @@ async def get_simplemodel(
 
 
 @app.get("/models/bert", dependencies=[Depends(verified_user)])
-async def get_bert(project: Annotated[Project, Depends(get_project)], name: str) -> Dict[str, Any]:
+async def get_bert(
+    project: Annotated[Project, Depends(get_project)], name: str
+) -> Dict[str, Any]:
     """
     Get Bert parameters and statistics
     """
@@ -1381,7 +1411,9 @@ async def predict(
     )
     if "error" in r:
         raise HTTPException(status_code=500, detail=r["error"])
-    server.log_action(current_user.username, f"INFO predict bert {model_name}", project.name)
+    server.log_action(
+        current_user.username, f"INFO predict bert {model_name}", project.name
+    )
     return None
 
 
@@ -1423,7 +1455,9 @@ async def post_bert(
 
     if "error" in r:
         raise HTTPException(status_code=500, detail=r["error"])
-    server.log_action(current_user.username, f"INFO train bert {bert.name}", project.name)
+    server.log_action(
+        current_user.username, f"INFO train bert {bert.name}", project.name
+    )
     return None
 
 
@@ -1473,7 +1507,9 @@ async def start_test(
     )
     if "error" in r:
         raise HTTPException(status_code=500, detail=r["error"])
-    server.log_action(current_user.username, "INFO predict bert for testing", project.name)
+    server.log_action(
+        current_user.username, "INFO predict bert for testing", project.name
+    )
     return None
 
 
@@ -1491,7 +1527,9 @@ async def delete_bert(
     r = project.bertmodels.delete(bert_name)
     if "error" in r:
         raise HTTPException(status_code=500, detail=r["error"])
-    server.log_action(current_user.username, f"INFO delete bert model {bert_name}", project.name)
+    server.log_action(
+        current_user.username, f"INFO delete bert model {bert_name}", project.name
+    )
     return None
 
 

--- a/api/activetigger/db/__init__.py
+++ b/api/activetigger/db/__init__.py
@@ -1,2 +1,36 @@
+"""
+In order to enforce the single-responsability rule, the models definitions are in db.models.py and CRUD functions are splitted into the designated object service (i.e. users operations are in users.py)
+
+Rules of thumb:
+    * Models are in db.models.py, this is the mapping between ORM entities and SQL tables
+    * If two entities are linked, the relationship should be declared into the model definition
+    * Each "domain" should have a service class that encapsulate the CRUD operation
+
+Checklist:
+    * Split ProjectsService.py: 1 file per entity
+    * Use with keyword for session management (see UsersService.py for reference)
+    * Use SQLAlchemy 2.0 API as often as possible
+
+SQLAlchemy 2.0 recipes:
+    Every SQL operation should be encapsulated into a session. Session should be handle with a "context manager", aka the `with` keyword.
+    ```python
+        with Session() as session:
+            session.execute(...)
+
+        print("session is automatically closed outside of the with block")
+
+        with Session.begin() as session:
+            session.execute(update(...)) # change/add something
+
+        print("session is automatically committed and closed thanks to .begin()")
+    ```
+    The `Query` object is now in a [legacy state](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html) since 2.0. The recommanded method is now to use designated function like `select()`, `update()` and such.
+    ```python
+        with Session() as session:
+            same_name_users = session.scalars(select(Users).filter_by(name=username)).all()
+    ```
+"""
+
+
 class DBException(Exception):
     pass

--- a/api/activetigger/db/__init__.py
+++ b/api/activetigger/db/__init__.py
@@ -1,0 +1,2 @@
+class DBException(Exception):
+    pass

--- a/api/activetigger/db/manager.py
+++ b/api/activetigger/db/manager.py
@@ -1,0 +1,49 @@
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from activetigger.db import DBException
+from activetigger.db.models import Base
+from activetigger.db.projects import ProjectsService
+from activetigger.db.users import UsersService
+from activetigger.functions import get_hash, get_root_pwd
+
+
+class DatabaseManager:
+    """
+    Database management with SQLAlchemy
+    """
+
+    engine: Engine
+    SessionMaker: sessionmaker[Session]
+    default_user: str
+    users_service: UsersService
+    projets_service: ProjectsService
+
+    def __init__(self, path_db: str):
+        db_url = f"sqlite:///{path_db}"
+
+        # connect the session
+        self.engine = create_engine(db_url)
+        self.SessionMaker = sessionmaker(bind=self.engine)
+        self.default_user = "server"
+        self.users_service = UsersService(self.SessionMaker)
+        self.projets_service = ProjectsService(self.SessionMaker)
+
+        # Create tables if not already present
+        Base.metadata.create_all(self.engine)
+
+        # check if there is a root user, add it
+        try:
+            _ = self.users_service.get_user("root")
+        except DBException:
+            self.create_root_session()
+
+    def create_root_session(self) -> None:
+        """
+        Create root session
+        :return: None
+        """
+        pwd: str = get_root_pwd()
+        hash_pwd: bytes = get_hash(pwd)
+        self.users_service.add_user("root", hash_pwd.hex(), "root", "system")

--- a/api/activetigger/db/models.py
+++ b/api/activetigger/db/models.py
@@ -1,0 +1,205 @@
+import datetime
+from typing import Any, List
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.types import JSON
+
+
+class Base(DeclarativeBase):
+    type_annotation_map = {dict[str, Any]: JSON}
+
+
+class Projects(Base):
+    __tablename__: str = "projects"
+
+    project_slug: Mapped[str] = mapped_column(primary_key=True)
+    time_created: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    time_modified: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+    )
+    parameters: Mapped[dict[str, Any]]
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped["Users"] = relationship("Users")
+    schemes: Mapped[List["Schemes"]] = relationship(
+        "Schemes", cascade="all, delete-orphan", back_populates="project"
+    )
+    annotations: Mapped[List["Annotations"]] = relationship(
+        "Annotations", cascade="all, delete-orphan", back_populates="project"
+    )
+    auths: Mapped[List["Auths"]] = relationship(
+        "Auths", cascade="all, delete-orphan", back_populates="project"
+    )
+    logs: Mapped[List["Logs"]] = relationship(
+        "Logs", cascade="all, delete-orphan", back_populates="project"
+    )
+    generations: Mapped[List["Generations"]] = relationship(
+        "Generations", cascade="all, delete-orphan", back_populates="project"
+    )
+    features: Mapped[List["Features"]] = relationship(
+        "Features", cascade="all, delete-orphan", back_populates="project"
+    )
+    models: Mapped[List["Models"]] = relationship(
+        "Models", cascade="all, delete-orphan", back_populates="project"
+    )
+
+
+class Users(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    time: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    user: Mapped[str]
+    key: Mapped[str]
+    description: Mapped[str]
+    contact: Mapped[str] = mapped_column(Text)
+    created_by: Mapped[str]
+    projects: Mapped[List[Projects]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+
+
+class Schemes(Base):
+    __tablename__ = "schemes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    time_created: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    time_modified: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+    )
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped[Users] = relationship()
+    project_id: Mapped[str] = mapped_column(ForeignKey("projects.project_slug"))
+    project: Mapped[Projects] = relationship(back_populates="schemes")
+    models: Mapped[List["Models"]] = relationship()
+    name: Mapped[str]
+    params: Mapped[dict[str, Any]]
+
+
+class Annotations(Base):
+    __tablename__ = "annotations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    time: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    dataset: Mapped[str]
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped[Users] = relationship()
+    project_id: Mapped[str] = mapped_column(ForeignKey("projects.project_slug"))
+    project: Mapped[Projects] = relationship(back_populates="annotations")
+    element_id: Mapped[str]
+    scheme_id: Mapped[int] = mapped_column(ForeignKey("schemes.id"))
+    scheme: Mapped[Schemes] = relationship()
+    annotation: Mapped[str]
+    comment: Mapped[str] = mapped_column(Text)
+
+
+class Auths(Base):
+    __tablename__ = "auth"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped[Users] = relationship()
+    project_id: Mapped[str] = mapped_column(ForeignKey("projects.project_slug"))
+    project: Mapped[Projects] = relationship(back_populates="auths")
+    status: Mapped[str]
+    created_by: Mapped[str]
+
+
+class Logs(Base):
+    __tablename__ = "logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    time: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped[Users] = relationship()
+    project_id: Mapped[str] = mapped_column(ForeignKey("projects.project_slug"))
+    project: Mapped[Projects] = relationship(back_populates="logs")
+    action: Mapped[str]
+    connect: Mapped[str]
+
+
+class Tokens(Base):
+    __tablename__ = "tokens"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    time_created: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    token: Mapped[str]
+    status: Mapped[str]
+    time_revoked: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True))
+
+
+class Generations(Base):
+    __tablename__ = "generations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    time: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped[Users] = relationship()
+    project_id: Mapped[str] = mapped_column(ForeignKey("projects.project_slug"))
+    project: Mapped[Projects] = relationship(back_populates="generations")
+    element_id: Mapped[str]
+    endpoint: Mapped[str]
+    prompt: Mapped[str]
+    answer: Mapped[str]
+
+
+class Features(Base):
+    __tablename__ = "features"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    time: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped[Users] = relationship()
+    project_id: Mapped[str] = mapped_column(ForeignKey("projects.project_slug"))
+    project: Mapped[Projects] = relationship(back_populates="features")
+    name: Mapped[str]
+    kind: Mapped[str]
+    parameters: Mapped[str]
+    data: Mapped[str]
+
+
+class Models(Base):
+    __tablename__ = "models"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    time: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    time_modified: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+    )
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped[Users] = relationship()
+    project_id: Mapped[str] = mapped_column(ForeignKey("projects.project_slug"))
+    project: Mapped[Projects] = relationship(back_populates="models")
+    scheme_id: Mapped[int] = mapped_column(ForeignKey("schemes.id"))
+    scheme: Mapped[Schemes] = relationship(back_populates="models")
+    kind: Mapped[str]
+    name: Mapped[str]
+    parameters: Mapped[str]
+    path: Mapped[str]
+    status: Mapped[str]
+    statistics: Mapped[str]
+    test: Mapped[str]

--- a/api/activetigger/db/users.py
+++ b/api/activetigger/db/users.py
@@ -1,0 +1,64 @@
+from sqlalchemy import delete, select, update
+from sqlalchemy.orm import Session, sessionmaker
+
+from activetigger.db import DBException
+from activetigger.db.models import Users
+
+
+class UsersService:
+    SessionMaker: sessionmaker[Session]
+
+    def __init__(self, sessionmaker: sessionmaker[Session]):
+        self.SessionMaker = sessionmaker
+
+    def get_user(self, username: str) -> Users:
+        # Context manager (with) will automatically close the session outside of its scope
+        with self.SessionMaker() as session:
+            user = session.scalars(select(Users).filter_by(user=username)).first()
+            if user is None:
+                raise DBException(f"User {username} not found")
+            return user
+
+    def add_user(
+        self,
+        username: str,
+        password: str,
+        role: str,
+        created_by: str,
+        contact: str = "",
+    ) -> None:
+        # with .begin(), it also commit the transaction
+        with self.SessionMaker.begin() as session:
+            user = Users(
+                user=username,
+                key=password,
+                description=role,
+                created_by=created_by,
+                # time=datetime.datetime.now(), ← This is default value
+                contact=contact,
+            )
+            session.add(user)
+
+    def get_users_created_by(self, username: str):
+        """
+        get users created by *username*
+        """
+        with self.SessionMaker() as session:
+            stmt = select(Users.user, Users.contact)
+            if username != "all":
+                stmt = stmt.filter_by(created_by=username)
+            stmt = stmt.distinct()
+            return {
+                row.user: {"contact": row.contact}
+                for row in session.scalars(stmt).all()
+            }
+
+    def delete_user(self, username: str) -> None:
+        with self.SessionMaker.begin() as session:
+            _ = session.execute(delete(Users).filter_by(user=username))
+
+    def change_password(self, username: str, password: str) -> None:
+        with self.SessionMaker.begin() as session:
+            _ = session.execute(
+                update(Users).filter_by(user=username).values(key=password)
+            )

--- a/api/activetigger/features.py
+++ b/api/activetigger/features.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pyarrow.parquet as pq
 from pandas import DataFrame, Series
 
-from activetigger.db import DatabaseManager
+from activetigger.db.projects import ProjectsService
 from activetigger.functions import to_dtm, to_fasttext, to_sbert
 from activetigger.queue import Queue
 
@@ -36,7 +36,7 @@ class Features:
     computing: dict
     options: dict
     lang: str
-    db_manager: DatabaseManager
+    projects_service: ProjectsService
     n: int
 
     def __init__(
@@ -54,7 +54,7 @@ class Features:
         Initit features
         """
         self.project_slug = project_slug
-        self.db_manager = db_manager
+        self.projects_service = db_manager.projects_service
         self.path_train = path_train
         self.path_all = path_all
         self.path_models = models_path

--- a/api/activetigger/functions.py
+++ b/api/activetigger/functions.py
@@ -106,12 +106,12 @@ def get_root_pwd() -> str:
             return root_password
 
 
-def get_hash(text: str):
+def get_hash(text: str) -> bytes:
     """
     Build a hash string from text
     """
     salt = bcrypt.gensalt()
-    hashed = bcrypt.hashpw(text.encode(), salt)
+    hashed: bytes = bcrypt.hashpw(text.encode(), salt)
     return hashed
 
 
@@ -236,7 +236,9 @@ def to_fasttext(texts: Series, language: str, path_models: Path, **kwargs) -> Da
     if not path_models.exists():
         return {"error": f"path {str(path_models)} does not exist"}
     os.chdir(path_models)
-    print("If the model doesn't exist, it will be downloaded first. It could talke some time.")
+    print(
+        "If the model doesn't exist, it will be downloaded first. It could talke some time."
+    )
     model_name = download_model(language, if_exists="ignore")
     print("Model loaded")
     texts_tk = tokenize(texts)
@@ -447,7 +449,9 @@ def train_bert(
     log_path = current_path.joinpath("status.log")
     logger = logging.getLogger("train_bert_model")
     file_handler = logging.FileHandler(log_path)
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
     logger.info(f"Start {base_model}")
@@ -553,7 +557,9 @@ def train_bert(
             args=training_args,
             train_dataset=df["train"],
             eval_dataset=df["test"],
-            callbacks=[CustomLoggingCallback(event, current_path=current_path, logger=logger)],
+            callbacks=[
+                CustomLoggingCallback(event, current_path=current_path, logger=logger)
+            ],
         )
 
         try:
@@ -630,7 +636,9 @@ def predict_bert(
     progress_path = path / "progress_predict"
     logger = logging.getLogger("predict_bert_model")
     file_handler = logging.FileHandler(log_path)
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 
@@ -648,7 +656,9 @@ def predict_bert(
         # Start prediction with batches
         predictions = []
         # logging the process
-        for chunk in [df[col_text][i : i + batch] for i in range(0, df.shape[0], batch)]:
+        for chunk in [
+            df[col_text][i : i + batch] for i in range(0, df.shape[0], batch)
+        ]:
             # user interrupt
             if event.is_set():
                 logger.info("Event set, stopping training.")

--- a/api/activetigger/functions.py
+++ b/api/activetigger/functions.py
@@ -284,7 +284,9 @@ def to_sbert(
         print("start computation")
         if device.type == "cuda":
             with autocast(device_type=str(device)):
-                emb = sbert.encode(list(texts), device=str(device), batch_size=batch_size)
+                emb = sbert.encode(
+                    list(texts), device=str(device), batch_size=batch_size
+                )
         else:
             emb = sbert.encode(list(texts), batch_size=batch_size, device=str(device))
         emb = pd.DataFrame(emb, index=texts.index)

--- a/api/activetigger/generations.py
+++ b/api/activetigger/generations.py
@@ -1,7 +1,8 @@
 import pandas as pd
 from pandas import DataFrame
 
-from activetigger.db import DatabaseManager
+from activetigger.db.manager import DatabaseManager
+from activetigger.db.projects import ProjectsService
 
 
 class Generations:
@@ -10,10 +11,10 @@ class Generations:
     """
 
     computing: list
-    db_manager: DatabaseManager
+    projects_service: ProjectsService
 
     def __init__(self, db_manager: DatabaseManager, computing: list) -> None:
-        self.db_manager = db_manager
+        self.projects_service = db_manager.projects_service
         self.computing = computing  # user:{"unique_id", "number","api"}
 
     def add(
@@ -28,7 +29,7 @@ class Generations:
         """
         Add a generated element in the database
         """
-        self.db_manager.add_generated(
+        self.projects_service.add_generated(
             user=user,
             project_slug=project_slug,
             element_id=element_id,
@@ -47,7 +48,7 @@ class Generations:
         """
         Get generated elements from the database
         """
-        result = self.db_manager.get_generated(
+        result = self.projects_service.get_generated(
             project_slug=project_slug, username=username, n_elements=n_elements
         )
         df = pd.DataFrame(

--- a/api/activetigger/models.py
+++ b/api/activetigger/models.py
@@ -242,7 +242,9 @@ class BertModel:
                 "f1_micro": round(f1_score(Y, Y_pred, average="micro"), decimals),
                 "f1_macro": round(f1_score(Y, Y_pred, average="macro"), decimals),
                 "f1_weighted": round(f1_score(Y, Y_pred, average="weighted"), decimals),
-                "f1": [round(i, decimals) for i in list(f1_score(Y, Y_pred, average=None))],
+                "f1": [
+                    round(i, decimals) for i in list(f1_score(Y, Y_pred, average=None))
+                ],
                 "precision": [
                     round(i, decimals)
                     for i in precision_score(list(Y), list(Y_pred), average="micro")
@@ -342,7 +344,9 @@ class BertModels:
                     )
                 else:
                     # create a flag
-                    with open(self.path / "../../static" / f"{m['name']}.tar.gz", "w") as f:
+                    with open(
+                        self.path / "../../static" / f"{m['name']}.tar.gz", "w"
+                    ) as f:
                         f.write("process started")
                     # start compression
                     self.start_compression(m["name"])
@@ -459,7 +463,9 @@ class BertModels:
         if params["gpu"]:
             mem = functions.get_gpu_memory_info()
             if self.estimate_memory_use(name, kind="train") > mem["available_memory"]:
-                return {"error": "Not enough GPU memory available. Wait or reduce batch."}
+                return {
+                    "error": "Not enough GPU memory available. Wait or reduce batch."
+                }
 
         # launch as a independant process
         args = {
@@ -696,7 +702,9 @@ class BertModels:
         """
         if element["status"] == "training":
             # update bdd status
-            self.db_manager.change_model_status(self.project_slug, element["model"].name, "trained")
+            self.db_manager.change_model_status(
+                self.project_slug, element["model"].name, "trained"
+            )
             self.projects_service.change_model_status(
                 self.project_slug, element["model"].name, "trained"
             )
@@ -802,7 +810,11 @@ class SimpleModels:
         """
         Currently under training
         """
-        r = {e["user"]: list(e["scheme"]) for e in self.computing if e["kind"] == "simplemodel"}
+        r = {
+            e["user"]: list(e["scheme"])
+            for e in self.computing
+            if e["kind"] == "simplemodel"
+        }
         return r
 
     def exists(self, user: str, scheme: str):
@@ -881,7 +893,9 @@ class SimpleModels:
 
         # Select model
         if name == "knn":
-            model = KNeighborsClassifier(n_neighbors=int(model_params["n_neighbors"]), n_jobs=-1)
+            model = KNeighborsClassifier(
+                n_neighbors=int(model_params["n_neighbors"]), n_jobs=-1
+            )
 
         if name == "lasso":
             model = LogisticRegression(
@@ -903,7 +917,9 @@ class SimpleModels:
                 n_estimators=int(model_params["n_estimators"]),
                 random_state=42,
                 max_features=(
-                    int(model_params["max_features"]) if model_params["max_features"] else None
+                    int(model_params["max_features"])
+                    if model_params["max_features"]
+                    else None
                 ),
                 n_jobs=-1,
             )
@@ -926,7 +942,9 @@ class SimpleModels:
         # TODO: refactore the SimpleModel class / move to API the executor call ?
         args = {"model": model, "X": X, "Y": Y, "labels": labels}
         unique_id = self.queue.add("simplemodel", functions.fit_model, args)
-        sm = SimpleModel(name, user, X, Y, labels, "computing", features, standardize, model_params)
+        sm = SimpleModel(
+            name, user, X, Y, labels, "computing", features, standardize, model_params
+        )
         self.computing.append(
             {
                 "user": user,
@@ -1032,7 +1050,9 @@ class SimpleModel:
 
     def compute_stats(self):
         self.proba = self.compute_proba(self.model, self.X)
-        self.statistics = self.compute_statistics(self.model, self.X, self.Y, self.labels)
+        self.statistics = self.compute_statistics(
+            self.model, self.X, self.Y, self.labels
+        )
         self.cv10 = self.compute_10cv(self.model, self.X, self.Y)
 
     def compute_proba(self, model, X):

--- a/api/activetigger/schemes.py
+++ b/api/activetigger/schemes.py
@@ -102,7 +102,9 @@ class Schemes:
             self.project_slug, scheme
         )
         # Shape the data
-        df = pd.DataFrame(results, columns=["id", "labels", "user", "time"])  # shape as a dataframe
+        df = pd.DataFrame(
+            results, columns=["id", "labels", "user", "time"]
+        )  # shape as a dataframe
 
         def agg(x):
             return list(x)[0] if len(x) > 0 else None  # take the label else None
@@ -114,13 +116,17 @@ class Schemes:
             lambda x: len(set([i for i in x if pd.notna(i)])) > 1, axis=1
         )  # filter for disagreement
         users = list(df.columns)
-        df = pd.DataFrame(df.apply(lambda x: x.to_dict(), axis=1), columns=["annotations"])
+        df = pd.DataFrame(
+            df.apply(lambda x: x.to_dict(), axis=1), columns=["annotations"]
+        )
         df = df.join(self.content[["text"]], how="left")  # add the text
         df = df[f_multi].reset_index()
         # return the result
         return df, users
 
-    def convert_annotations(self, former_label: str, new_label: str, scheme: str, username: str):
+    def convert_annotations(
+        self, former_label: str, new_label: str, scheme: str, username: str
+    ):
         """
         Convert tags from a specific label to another
         """
@@ -245,7 +251,9 @@ class Schemes:
             "filter": contains,
         }
 
-    def add_scheme(self, name: str, labels: list, kind: str = "multiclass", user: str = "server"):
+    def add_scheme(
+        self, name: str, labels: list, kind: str = "multiclass", user: str = "server"
+    ):
         """
         Add new scheme
         """

--- a/api/activetigger/server.py
+++ b/api/activetigger/server.py
@@ -24,7 +24,6 @@ from activetigger.datamodels import (
     TestSetDataModel,
 )
 from activetigger.db.manager import DatabaseManager
-from activetigger.db.users import UsersService
 from activetigger.features import Features
 from activetigger.functions import cat2num, clean_regex
 from activetigger.generations import Generations
@@ -32,6 +31,7 @@ from activetigger.models import BertModels, SimpleModels
 from activetigger.projections import Projections
 from activetigger.queue import Queue
 from activetigger.schemes import Schemes
+from activetigger.users import Users
 
 logger = logging.getLogger("server")
 
@@ -71,7 +71,7 @@ class Server:
     projects: dict
     db_manager: DatabaseManager
     queue: Queue
-    users: UsersService
+    users: Users
     max_projects: int
 
     def __init__(self, path=".", path_models="./models") -> None:
@@ -123,7 +123,7 @@ class Server:
         self.projects = {}
         self.db_manager = DatabaseManager(str(self.db))
         self.queue = Queue(self.n_workers)
-        self.users = self.db_manager.users_service
+        self.users = Users(self.db_manager)
 
         # logging
         logging.basicConfig(
@@ -155,12 +155,16 @@ class Server:
         self.db_manager.add_log(user, action, project, connect)
         logger.info("%s from %s in project %s", action, user, project)
 
-    def get_logs(self, project_slug: str, limit: int, partial: bool = True) -> pd.DataFrame:
+    def get_logs(
+        self, project_slug: str, limit: int, partial: bool = True
+    ) -> pd.DataFrame:
         """
         Get logs for a user/project
         """
         logs = self.db_manager.get_logs("all", project_slug, limit)
-        df = pd.DataFrame(logs, columns=["id", "time", "user", "project", "action", "NA"])
+        df = pd.DataFrame(
+            logs, columns=["id", "time", "user", "project", "action", "NA"]
+        )
         if partial:
             return df[~df["action"].str.contains("INFO ")]
         return df
@@ -255,11 +259,15 @@ class Server:
 
         if existing_project:
             # Update the existing project
-            self.db_manager.update_project(project.project_slug, jsonable_encoder(project))
+            self.db_manager.update_project(
+                project.project_slug, jsonable_encoder(project)
+            )
             return {"success": "project updated"}
         else:
             # Insert a new project
-            self.db_manager.add_project(project.project_slug, jsonable_encoder(project), username)
+            self.db_manager.add_project(
+                project.project_slug, jsonable_encoder(project), username
+            )
             return {"success": "project added"}
 
     def existing_projects(self) -> list:
@@ -337,7 +345,10 @@ class Server:
         # case of a column as index
         else:
             # check if index after slugify is unique otherwise throw an error
-            if not ((content[params.col_id].astype(str).apply(slugify)).nunique() == len(content)):
+            if not (
+                (content[params.col_id].astype(str).apply(slugify)).nunique()
+                == len(content)
+            ):
                 shutil.rmtree(params.dir)
                 return {"error": "The column selected for index has not unique values."}
             content["id"] = content[params.col_id].astype(str).apply(slugify)
@@ -384,7 +395,9 @@ class Server:
                 df_grouped = content.groupby(params.cols_test, group_keys=False)
                 nb_cat = len(df_grouped)
                 nb_elements_cat = round(params.n_test / nb_cat)
-                testset = df_grouped.apply(lambda x: x.sample(min(len(x), nb_elements_cat)))
+                testset = df_grouped.apply(
+                    lambda x: x.sample(min(len(x), nb_elements_cat))
+                )
             testset.to_parquet(params.dir.joinpath(self.test_file), index=True)
             params.test = True
             rows_test = list(testset.index)
@@ -394,11 +407,15 @@ class Server:
         f_notna = content["label"].notna()
         f_na = content["label"].isna()
 
-        if f_notna.sum() > params.n_train:  # case where there is more labelled data than needed
+        if (
+            f_notna.sum() > params.n_train
+        ):  # case where there is more labelled data than needed
             trainset = content[f_notna].sample(params.n_train)
         else:
             n_train_random = params.n_train - f_notna.sum()  # number of element to pick
-            trainset = pd.concat([content[f_notna], content[f_na].sample(n_train_random)])
+            trainset = pd.concat(
+                [content[f_notna], content[f_na].sample(n_train_random)]
+            )
 
         trainset.to_parquet(params.dir.joinpath(self.train_file), index=True)
         trainset[list(set(["text"] + params.cols_context + keep_id))].to_parquet(
@@ -408,7 +425,9 @@ class Server:
 
         # if the case, add existing annotations in the database
         if params.col_label is None:
-            self.db_manager.add_scheme(project_slug, "default", [], "multiclass", "system")
+            self.db_manager.add_scheme(
+                project_slug, "default", [], "multiclass", "system"
+            )
         else:
             # determine if multiclass / multilabel (arbitrary rule)
             delimiters = content["label"].str.contains("|", regex=False).sum()
@@ -608,7 +627,9 @@ class Project(Server):
         )
 
         # change names
-        df = df.rename(columns={testset.col_id: "id", testset.col_text: "text"}).set_index("id")
+        df = df.rename(
+            columns={testset.col_id: "id", testset.col_text: "text"}
+        ).set_index("id")
 
         # write the dataset
         df[[testset.col_text]].to_parquet(self.params.dir.joinpath(self.test_file))
@@ -667,7 +688,9 @@ class Project(Server):
         counts = df_scheme["labels"].value_counts()
         valid_categories = counts[counts >= 3]
         if len(valid_categories) < 2:
-            return {"error": "there are less than 2 categories with 3 annotated elements"}
+            return {
+                "error": "there are less than 2 categories with 3 annotated elements"
+            }
 
         col_features = list(df_features.columns)
         data = pd.concat([df_scheme, df_features], axis=1)
@@ -769,7 +792,9 @@ class Project(Server):
                     )
                 )
             else:
-                f_regex = df["text"].str.contains(filter_san, regex=True, case=True, na=False)
+                f_regex = df["text"].str.contains(
+                    filter_san, regex=True, case=True, na=False
+                )
             f = f & f_regex
 
         # manage frame selection (if projection, only in the box)
@@ -817,7 +842,9 @@ class Project(Server):
             proba = sm.proba.reindex(f.index)
             # use the history to not send already tagged data
             ss = (
-                proba[f][label].drop(history, errors="ignore").sort_values(ascending=False)
+                proba[f][label]
+                .drop(history, errors="ignore")
+                .sort_values(ascending=False)
             )  # get max proba id
             element_id = ss.index[0]
             n_sample = f.sum()
@@ -831,7 +858,9 @@ class Project(Server):
             proba = sm.proba.reindex(f.index)
             # use the history to not send already tagged data
             ss = (
-                proba[f]["entropy"].drop(history, errors="ignore").sort_values(ascending=False)
+                proba[f]["entropy"]
+                .drop(history, errors="ignore")
+                .sort_values(ascending=False)
             )  # get max entropy id
             element_id = ss.index[0]
             n_sample = f.sum()
@@ -856,7 +885,9 @@ class Project(Server):
             "element_id": element_id,
             "text": self.content.fillna("NA").loc[element_id, "text"],
             "context": dict(
-                self.content.fillna("NA").loc[element_id, self.params.cols_context].apply(str)
+                self.content.fillna("NA")
+                .loc[element_id, self.params.cols_context]
+                .apply(str)
             ),
             "selection": selection,
             "info": indicator,
@@ -906,7 +937,9 @@ class Project(Server):
                 if self.simplemodels.exists(user, scheme):
                     sm = self.simplemodels.get_model(user, scheme)
                     predicted_label = sm.proba.loc[element_id, "prediction"]
-                    predicted_proba = round(sm.proba.loc[element_id, predicted_label], 2)
+                    predicted_proba = round(
+                        sm.proba.loc[element_id, predicted_label], 2
+                    )
                     predict = {"label": predicted_label, "proba": predicted_proba}
 
             # get element tags
@@ -918,7 +951,9 @@ class Project(Server):
                 "element_id": element_id,
                 "text": self.content.loc[element_id, "text"],
                 "context": dict(
-                    self.content.fillna("NA").loc[element_id, self.params.cols_context].apply(str)
+                    self.content.fillna("NA")
+                    .loc[element_id, self.params.cols_context]
+                    .apply(str)
                 ),
                 "selection": "request",
                 "predict": predict,
@@ -954,7 +989,8 @@ class Project(Server):
         # part train
         r = {"train_set_n": len(self.schemes.content)}
         r["users"] = [
-            i[0] for i in self.db_manager.get_coding_users(scheme, self.params.project_slug)
+            i[0]
+            for i in self.db_manager.get_coding_users(scheme, self.params.project_slug)
         ]
 
         df = self.schemes.get_scheme_data(scheme, kind=["train", "predict"])
@@ -962,7 +998,9 @@ class Project(Server):
         # different treatment if the scheme is multilabel or multiclass
         r["train_annotated_n"] = len(df.dropna(subset=["labels"]))
         if kind == "multiclass":
-            r["train_annotated_distribution"] = json.loads(df["labels"].value_counts().to_json())
+            r["train_annotated_distribution"] = json.loads(
+                df["labels"].value_counts().to_json()
+            )
         else:
             r["train_annotated_distribution"] = json.loads(
                 df["labels"].str.split("|").explode().value_counts().to_json()
@@ -974,7 +1012,9 @@ class Project(Server):
             r["test_set_n"] = len(self.schemes.test)
             r["test_annotated_n"] = len(df.dropna(subset=["labels"]))
             if kind == "multiclass":
-                r["test_annotated_distribution"] = json.loads(df["labels"].value_counts().to_json())
+                r["test_annotated_distribution"] = json.loads(
+                    df["labels"].value_counts().to_json()
+                )
             else:
                 r["test_annotated_distribution"] = json.loads(
                     df["labels"].str.split("|").explode().value_counts().to_json()
@@ -1024,7 +1064,8 @@ class Project(Server):
             "projections": {
                 "options": self.projections.options,
                 "available": {
-                    i: self.projections.available[i]["id"] for i in self.projections.available
+                    i: self.projections.available[i]["id"]
+                    for i in self.projections.available
                 },
                 "training": self.projections.training(),  # list(self.projections.training().keys()),
             },
@@ -1076,7 +1117,9 @@ class Project(Server):
         if dataset == "test":
             if not self.params.test:
                 return {"error": "No test data"}
-            data = self.schemes.get_scheme_data(scheme=scheme, complete=True, kind="test")
+            data = self.schemes.get_scheme_data(
+                scheme=scheme, complete=True, kind="test"
+            )
             file_name = f"data_test_{self.name}_{scheme}.{format}"
         else:
             data = self.schemes.get_scheme_data(scheme=scheme, complete=True)
@@ -1151,7 +1194,9 @@ class Project(Server):
                         print("Error in model training/predicting", r["error"])
                         self.computing.remove(e)
                         self.queue.delete(e["unique_id"])
-                        self.errors.append([datetime.now(TIMEZONE), "bert training", r["error"]])
+                        self.errors.append(
+                            [datetime.now(TIMEZONE), "bert training", r["error"]]
+                        )
                         # return {"error": r["error"]}
                     if "prediction" in r:
                         predictions["predict_" + e["model"].name] = r["prediction"]
@@ -1175,7 +1220,9 @@ class Project(Server):
                     self.simplemodels.add(e, results)
                     print("Simplemodel trained")
                 except Exception as ex:
-                    self.errors.append([datetime.now(TIMEZONE), "simplemodel failed", str(ex)])
+                    self.errors.append(
+                        [datetime.now(TIMEZONE), "simplemodel failed", str(ex)]
+                    )
                     print("Simplemodel failed", ex)
 
             # case for features


### PR DESCRIPTION
In order to have smaller and "single-responsability" files, I put the models definition in db.models.py and started to split CRUD function into the designated object service (i.e. users operations are in users.py)

## Rules of thumb

- Models are in `db.models.py`, this is the mapping between ORM entities and SQL tables
- If two entities are linked, the relationship should be declared into the model definition
- Each "domain" should have a service class that encapsulate the CRUD operation

## State

I already review the models and created a `UsersService` that can be used as a reference. I put all the other methods in the `ProjectsService` for now, but this should be splitted too.

## Checklist

- [ ] Split `ProjectsService.py`: 1 file per entity
- [ ] Use `with` keyword for session management (see `UsersService.py` for reference)
- [ ] Use SQLAlchemy 2.0 API as often as possible

@Carreau I'd be happy to have your feedback on this scaffolding/architecture