### PR TITLE
Fix SQL relationship in queries

### DIFF
--- a/api/activetigger/api.py
+++ b/api/activetigger/api.py
@@ -1,10 +1,11 @@
 import importlib
 import logging
 import time
+from collections.abc import Awaitable
 from contextlib import asynccontextmanager
 from datetime import datetime
 from io import StringIO
-from typing import Annotated, Any
+from typing import Annotated, Any, Callable
 
 import pandas as pd
 from fastapi import (
@@ -192,7 +193,9 @@ async def check_processes(timer: float, step: int = 1) -> None:
 
 
 @app.middleware("http")
-async def middleware(request: Request, call_next):
+async def middleware(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+):
     """
     Middleware to take care of completed processes
     Executed at each action on the server

--- a/api/activetigger/db/models.py
+++ b/api/activetigger/db/models.py
@@ -114,7 +114,7 @@ class Auths(Base):
     project_id: Mapped[str] = mapped_column(ForeignKey("projects.project_slug"))
     project: Mapped[Projects] = relationship(back_populates="auths")
     status: Mapped[str]
-    created_by: Mapped[str]
+    created_by: Mapped[str | None]
 
 
 class Logs(Base):

--- a/api/activetigger/features.py
+++ b/api/activetigger/features.py
@@ -139,7 +139,7 @@ class Features:
         del content
 
         # add informations to database
-        self.db_manager.add_feature(
+        self.projects_service.add_feature(
             project=self.project_slug,
             kind=kind,
             name=name,
@@ -160,7 +160,7 @@ class Features:
         if name not in self.map:
             return {"error": "feature doesn't exist in mapping"}
 
-        if self.db_manager.get_feature(self.project_slug, name) is None:
+        if self.projects_service.get_feature(self.project_slug, name) is None:
             return {"error": "feature doesn't exist in database"}
 
         col = self.get([name])
@@ -172,7 +172,7 @@ class Features:
         del content
 
         # delete from database
-        self.db_manager.delete_feature(self.project_slug, name)
+        self.projects_service.delete_feature(self.project_slug, name)
 
         # refresh the map
         self.map = self.get_map()[0]
@@ -205,7 +205,7 @@ class Features:
         return data
 
     def info(self, name: str):
-        feature = self.db_manager.get_feature(self.project_slug, name)
+        feature = self.projects_service.get_feature(self.project_slug, name)
         if feature is None:
             return {"error": "feature doesn't exist in database"}
         return {
@@ -224,7 +224,7 @@ class Features:
             Maybe not the best solution
             Database ? How to avoid a loop ...
         """
-        features = self.db_manager.get_project_features(self.project_slug)
+        features = self.projects_service.get_project_features(self.project_slug)
         return features
 
     def get_column_raw(self, column_name: str, index: str = "train") -> dict:

--- a/api/activetigger/server.py
+++ b/api/activetigger/server.py
@@ -188,7 +188,7 @@ class Server:
         """
         Get project params from database
         """
-        existing_project = self.db_manager.get_project(project_slug)
+        existing_project = self.db_manager.projects_service.get_project(project_slug)
         if existing_project:
             return ProjectModel(**json.loads(existing_project["parameters"]))
         else:
@@ -990,7 +990,9 @@ class Project(Server):
         r = {"train_set_n": len(self.schemes.content)}
         r["users"] = [
             i[0]
-            for i in self.db_manager.get_coding_users(scheme, self.params.project_slug)
+            for i in self.db_manager.projects_service.get_coding_users(
+                scheme, self.params.project_slug
+            )
         ]
 
         df = self.schemes.get_scheme_data(scheme, kind=["train", "predict"])
@@ -1140,7 +1142,7 @@ class Project(Server):
         """
         Get current active users on the time period
         """
-        users = self.db_manager.get_distinct_users(self.name, period)
+        users = self.db_manager.projects_service.get_distinct_users(self.name, period)
         return users
 
     def get_process(self, kind: str, user: str):


### PR DESCRIPTION
When filtering on relations, be sure to use the `_id` (i.e. `Features.project_id`), containing only the literal ID, instead of the `project`, containing the entire `Projects` object (joined by the ORM)